### PR TITLE
chore(ci): update cimg, noissue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,18 @@
-version: 2
+version: 2.1
 
-defaults: &defaults
-  working_directory: ~/repo
-  docker:
-    - image: circleci/node:lts
-cache_key: &cache_key
-  key: dependency-cache-lts-{{ checksum "package.json" }}
+aliases:
+  - &cache-key dependency-cache-{{ checksum "package.json" }}
+  - &cache-key-fallback dependency-cache-
+ 
+executors:
+  default:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/node:lts
 
 jobs:
   checkout_code:
-    <<: *defaults
+    executor: default
     steps:
       - checkout
       - persist_to_workspace:
@@ -17,32 +20,28 @@ jobs:
           paths:
             - . 
   test:
-    <<: *defaults
+    executor: default
     steps:
       - attach_workspace:
           at: ~/repo
       - restore_cache:
-          <<: *cache_key
-      - run:
-          name: install dependencies with npm
-          command: npm install
-      - run:
-          name: rebuild dependencies with npm - incase node version has changed
-          command: npm rebuild
+          keys:
+            - *cache-key
+            - *cache-key-fallback
+      - run: npm install
+      - run: npm rebuild
       - save_cache:
-          <<: *cache_key
+          key: *cache-key
           paths:
             - ./node_modules
-      - run:
-          name: npm tests
-          command: npm test
+      - run: npm test
       - persist_to_workspace:
           root: ~/repo
           paths:
             - node_modules
 
   release:
-    <<: *defaults
+    executor: default
     steps:
       - attach_workspace:
           at: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,8 @@
 version: 2.1
 
-aliases:
-  - &cache-key dependency-cache-{{ checksum "package.json" }}
-  - &cache-key-fallback dependency-cache-
- 
+orbs:
+  node: circleci/node@4.1
+
 executors:
   default:
     working_directory: ~/repo
@@ -11,51 +10,24 @@ executors:
       - image: cimg/node:lts
 
 jobs:
-  checkout_code:
-    executor: default
-    steps:
-      - checkout
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-            - . 
   test:
     executor: default
     steps:
-      - attach_workspace:
-          at: ~/repo
-      - restore_cache:
-          keys:
-            - *cache-key
-            - *cache-key-fallback
-      - run: npm install
-      - run: npm rebuild
-      - save_cache:
-          key: *cache-key
-          paths:
-            - ./node_modules
+      - checkout
+      - node/install-packages
       - run: npm test
-      - persist_to_workspace:
-          root: ~/repo
-          paths:
-            - node_modules
 
   release:
     executor: default
     steps:
-      - attach_workspace:
-          at: ~/repo
       - checkout
+      - node/install-packages
       - run: npm run semantic-release  
 
 workflows:
-  version: 2
   build:
     jobs:
-      - checkout_code
-      - test:
-          requires:
-            - checkout_code
+      - test
       - release:
           context: org-global
           requires:


### PR DESCRIPTION
Updates the node base image in our circleci config, after we received the following email advice...

> Why migrate?
> - More deterministic: The newest images will be rebuilt only for security and critical-bugs, drastically reducing breaking changes from updates in legacy images.
> - Faster build times: Our newest images get faster as our community uses them due to improved caching. Migrating to the new image is good for your builds and for the builds of the larger Node.js community.
> - As of Dec 31, 2021, legacy images will no longer be supported on CircleCI. View more information on our image deprecation timeline here.


... they should have lead with the deprecation notice (the last point)
